### PR TITLE
Improve camera station query performance

### DIFF
--- a/app/component/map/popups/CameraStationPopup.js
+++ b/app/component/map/popups/CameraStationPopup.js
@@ -10,8 +10,7 @@ import CardHeader from '../../CardHeader';
 import ImageSlider from '../../ImageSlider';
 import ComponentUsageExample from '../../ComponentUsageExample';
 
-function CameraStationPopup({ weatherCamera, trafficCamera, lang }, { intl }) {
-  const camera = weatherCamera || trafficCamera;
+function CameraStationPopup({ camera, lang }, { intl }) {
   const localName = camera.names[lang] || camera.name;
 
   return (
@@ -58,8 +57,7 @@ CameraStationPopup.description = (
 
 CameraStationPopup.propTypes = {
   lang: PropTypes.string.isRequired,
-  weatherCamera: PropTypes.object,
-  trafficCamera: PropTypes.object,
+  camera: PropTypes.object,
 };
 
 CameraStationPopup.contextTypes = {
@@ -72,26 +70,8 @@ export default Relay.createContainer(
   })),
   {
     fragments: {
-      weatherCamera: () => Relay.QL`
-        fragment on WeatherCamera {
-          cameraId
-          name
-          names {
-            fi
-            sv
-            en
-          }
-          presets {
-      			presetId
-            presentationName
-            imageUrl
-            direction
-            measuredTime
-          }
-        }
-      `,
-      trafficCamera: () => Relay.QL`
-        fragment on TrafficCamera {
+      camera: () => Relay.QL`
+        fragment on CameraInterface {
           cameraId
           name
           names {

--- a/app/route/CameraStationRoute.js
+++ b/app/route/CameraStationRoute.js
@@ -4,14 +4,9 @@ import Relay from 'react-relay/classic';
 
 export default class CameraStationRoute extends Relay.Route {
   static queries = {
-    weatherCamera: () => Relay.QL`
+    camera: () => Relay.QL`
       query ($id: String!) {
-        weatherCamera (id: $id)
-      }
-    `,
-    trafficCamera: () => Relay.QL`
-      query ($id: String!) {
-        trafficCamera (id: $id)
+        camera (id: $id)
       }
     `,
   };


### PR DESCRIPTION
Instead of batch querying both types of cameras, use the CameraInterface and let the GraphQL server manage which type of camera it is. The returned __typename will tell the client what kind of camera, i.e. "TrafficCamera" or "WeatherCamera", if needed.