### PR TITLE
Improve tile layer rendering for maintenance routes

### DIFF
--- a/app/component/map/tile-layer/MaintenanceVehicleRoutes.js
+++ b/app/component/map/tile-layer/MaintenanceVehicleRoutes.js
@@ -70,7 +70,7 @@ class MaintenanceVehicleRoutes {
 
           // Sort the features by their ID first and those without will be put last.
           // Then filter only unique features by their hash value, removing any features
-          // without an ID if there is one with that same ID.
+          // without an ID if there is one with that same hash.
           const sortedFeatures = sortBy(tileLayerFeatures, 'properties.id');
           const uniqueFeatures = uniqBy(sortedFeatures, 'properties.hash');
 

--- a/app/component/map/tile-layer/MaintenanceVehicleRoutes.js
+++ b/app/component/map/tile-layer/MaintenanceVehicleRoutes.js
@@ -1,5 +1,7 @@
 import { VectorTile } from '@mapbox/vector-tile';
 import get from 'lodash/get';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 import Protobuf from 'pbf';
 import { drawMaintenanceVehicleRoutePath } from '../../../util/mapIconUtils';
 import { isBrowser } from '../../../util/browser';
@@ -55,31 +57,46 @@ class MaintenanceVehicleRoutes {
             : 'maintenanceroutesnonmotorised';
 
         if (vt.layers[layerKey] != null) {
-          for (let i = 0, ref = vt.layers[layerKey].length - 1; i <= ref; i++) {
-            const feature = vt.layers[layerKey].feature(i);
-            const { jobId, timestamp } = feature.properties;
-
-            if (timestamp >= Date.now() / 1000 - this.timeRange * 60) {
-              const color =
-                MaintenanceJobColors[jobId] || MaintenanceJobColors[0];
-              const geometryList = feature.loadGeometry();
-
-              geometryList.forEach(geom => {
-                if (
-                  this.config.maintenanceVehicles &&
-                  this.config.maintenanceVehicles.showLines &&
-                  geom.length > 1
-                ) {
-                  drawMaintenanceVehicleRoutePath(this.tile, geom, color);
-
-                  this.features.push({
-                    lineString: geom,
-                    geom: null,
-                    properties: feature.properties,
-                  });
-                }
-              });
+          // Filter out any features that are not within the user selected time range.
+          const tileLayerFeatures = [];
+          const selectedTimeRange = ((Date.now() / 1000) - (this.timeRange * 60));
+          for (let j = 0, ll = vt.layers[layerKey].length - 1; j <= ll; j++) {
+            const feature = vt.layers[layerKey].feature(j);
+            const { timestamp } = feature.properties;
+            if (timestamp >= selectedTimeRange) {
+              tileLayerFeatures.push(feature);
             }
+          }
+
+          // Sort the features by their ID first and those without will be put last.
+          // Then filter only unique features by their hash value, removing any features
+          // without an ID if there is one with that same ID.
+          const sortedFeatures = sortBy(tileLayerFeatures, 'properties.id');
+          const uniqueFeatures = uniqBy(sortedFeatures, 'properties.hash');
+
+          // Draw the remaining features onto the map.
+          for (let i = 0, ref = uniqueFeatures.length - 1; i <= ref; i++) {
+            const feature = uniqueFeatures[i];
+            const { jobId } = feature.properties;
+
+            const color = MaintenanceJobColors[jobId] || MaintenanceJobColors[0];
+            const geometryList = feature.loadGeometry();
+
+            geometryList.forEach(geom => {
+              if (
+                this.config.maintenanceVehicles &&
+                this.config.maintenanceVehicles.showLines &&
+                geom.length > 1
+              ) {
+                drawMaintenanceVehicleRoutePath(this.tile, geom, color);
+
+                this.features.push({
+                  lineString: geom,
+                  geom: null,
+                  properties: feature.properties,
+                });
+              }
+            });
           }
         }
       });

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -506,7 +506,10 @@ class TileLayerContainer extends GridLayer {
             />
           );
         } else if (
-          this.state.selectableTargets[0].layer === 'maintenanceVehicles'
+          this.state.selectableTargets[0].layer === 'maintenanceVehicles' &&
+          this.state.selectableTargets[0].feature &&
+          this.state.selectableTargets[0].feature.properties &&
+          this.state.selectableTargets[0].feature.properties.id
         ) {
           ({ id } = this.state.selectableTargets[0].feature.properties);
           contents = (


### PR DESCRIPTION
The tile layer for maintenance routes now include the entire road geometry and rendering logic now determines what geometry to draw based on user selection and geometry properties so that the road geometry is rendered when no route events exists for that section of the road within the timespan the user has selected.
