### PR TITLE
Show only the closest selectable target from each layer

### DIFF
--- a/app/component/map/tile-layer/TileContainer.js
+++ b/app/component/map/tile-layer/TileContainer.js
@@ -238,6 +238,7 @@ class TileContainer {
             );
 
             if (pointToLineDist < 20) {
+              currentFeature.feature.dist = pointToLineDist;
               currentFeature.feature.geom = {
                 x: localPoint[0] * this.ratio,
                 y: localPoint[1] * this.ratio,


### PR DESCRIPTION
When the map is clicked, filter selectable targets so that only the closest ones are available from each layer. This prevents duplicate targets from being displayed in the popup.