### PR TITLE
Disable bicycle "other routes"

### DIFF
--- a/app/component/BicycleRoutesLegend.js
+++ b/app/component/BicycleRoutesLegend.js
@@ -8,7 +8,6 @@ import {
   BicycleRouteBaanaLines,
   BicycleRouteBrandLines,
   BicycleRouteMainRegionalLines,
-  BicycleRouteTypeLines,
 } from '../constants';
 import { getSortedItems } from '../util/bicycleRouteUtils';
 
@@ -45,9 +44,12 @@ const BicycleRoutesLegend = ({ mapLayers }) => {
         ...BicycleRouteMainRegionalLines,
       };
     }
-    if (mapLayers.bicycleRouteTypes) {
-      allSelectedLines = { ...allSelectedLines, ...BicycleRouteTypeLines };
-    }
+    // Bicycle route types currently not needed.
+    // Commented out instead of deleted in case
+    // we need to re-enable them in the future.
+    // if (mapLayers.bicycleRouteTypes) {
+    //   allSelectedLines = { ...allSelectedLines, ...BicycleRouteTypeLines };
+    // }
     return renderItems(allSelectedLines);
   };
 

--- a/app/component/EcoCounterContent.js
+++ b/app/component/EcoCounterContent.js
@@ -156,6 +156,7 @@ class EcoCounterContent extends React.Component {
         data: channel1Counts,
         borderColor: '#dc3545',
         backgroundColor: 'rgba(0,0,0,0)',
+        hidden: true,
       },
     ];
 
@@ -173,6 +174,7 @@ class EcoCounterContent extends React.Component {
         data: channel2Counts,
         borderColor: '#00AFFF',
         backgroundColor: 'rgba(0,0,0,0)',
+        hidden: true,
       });
     }
 
@@ -189,7 +191,7 @@ class EcoCounterContent extends React.Component {
         data: channelTotals,
         borderColor: '#FFC107',
         backgroundColor: 'rgba(0,0,0,0)',
-        hidden: true,
+        hidden: false,
       });
     }
 

--- a/app/component/LineChart.js
+++ b/app/component/LineChart.js
@@ -42,8 +42,25 @@ class LineChart extends React.Component {
     const currData = omitCircularReferences(this.props.datasets);
     const prevData = omitCircularReferences(prevProps.datasets);
 
+    // persist selections between updates based on order of datasets
+    const persistDatasetSelection = (chartInstance, incomingDataset) => {
+      if (chartInstance.data.datasets && chartInstance.data.datasets.length) {
+        for (let i = 0; i < chartInstance.data.datasets.length; i++) {
+          const isVisible = chartInstance.isDatasetVisible(i);
+          const incomingDatasetEntry = incomingDataset[i];
+          if (incomingDatasetEntry) {
+            incomingDatasetEntry.hidden = !isVisible;
+          }
+        }
+      }
+      return incomingDataset;
+    };
+
     if (this.props.datasets && this.chart && !isEqual(currData, prevData)) {
-      this.chart.data.datasets = this.props.datasets;
+      this.chart.data.datasets = persistDatasetSelection(
+        this.chart,
+        this.props.datasets,
+      );
       this.chart.data.labels = this.props.labels;
       this.chart.update();
     }

--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -162,7 +162,6 @@ class SelectMapLayersDialog extends React.Component {
       roadSigns,
       bicycleRoutes,
       bicycleRoutesMainRegional,
-      bicycleRouteTypes,
       bicycleRoutesBaana,
       bicycleRoutesBrand,
     } = this.props.mapLayers;
@@ -552,7 +551,10 @@ class SelectMapLayersDialog extends React.Component {
                       }
                     />
                   )}
-                  {isMapLayerEnabled('bicycleRouteTypes') && (
+                  {/* Bicycle route types currently not needed.
+                  Commented out instead of deleted in case
+                  we need to re-enable them in the future. */}
+                  {/* {isMapLayerEnabled('bicycleRouteTypes') && (
                     <InputField
                       checked={bicycleRouteTypes}
                       labelId="bicycle-routes-TYPES"
@@ -563,7 +565,7 @@ class SelectMapLayersDialog extends React.Component {
                         })
                       }
                     />
-                  )}
+                  )} */}
                 </div>
               )}
             </React.Fragment>

--- a/app/component/map/tile-layer/VectorTileLayerContainer.js
+++ b/app/component/map/tile-layer/VectorTileLayerContainer.js
@@ -22,7 +22,6 @@ import {
   BicycleRoutesBaana,
   BicycleRoutesBrand,
   BicycleRoutesMainRegional,
-  BicycleRouteTypes,
 } from './BicycleRoutes';
 
 class VectorTileLayerContainer extends React.Component {
@@ -113,7 +112,10 @@ class VectorTileLayerContainer extends React.Component {
 
       if (config.bicycleRoutes && config.bicycleRoutes.showBicycleRoutes) {
         layers.push(BicycleRoutesMainRegional);
-        layers.push(BicycleRouteTypes);
+        // Bicycle route types currently not needed.
+        // Commented out instead of deleted in case
+        // we need to re-enable them in the future.
+        // layers.push(BicycleRouteTypes);
         layers.push(BicycleRoutesBaana);
         layers.push(BicycleRoutesBrand);
       }


### PR DESCRIPTION
 - Disable other routes from map layers and
   routes legend. (Commented out in case they will
   be needed again in the future)
 - Persist line chart dataset selections between component
   updates.
 - Change default dataset selection to "Yhteensä"