### PR TITLE
Clear lingering realtime maintenance vehicles

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -112,6 +112,8 @@ export const MaintenanceJobPriorities = {
   0: 10,
 };
 
+export const MaintenanceVehicleAllowedInactivitySeconds = 120;
+
 export const BicycleRouteMainRegionalLines = {
   'MAIN_REGIONAL-MAIN': {
     color: '#FF4B00',

--- a/app/store/MaintenanceVehicleRealTimeInformationStore.js
+++ b/app/store/MaintenanceVehicleRealTimeInformationStore.js
@@ -1,6 +1,8 @@
 import Store from 'fluxible/addons/BaseStore';
 import PropTypes from 'prop-types';
 
+import { clearStaleMaintenanceVehicles } from '../util/maintenanceUtils';
+
 class MaintenanceVehicleRealTimeInformationStore extends Store {
   static storeName = 'MaintenanceVehicleRealTimeInformationStore';
 
@@ -37,9 +39,17 @@ class MaintenanceVehicleRealTimeInformationStore extends Store {
     this.emitChange();
   }
 
+  clearStaleVehicles() {
+    this.maintenanceVehicles = clearStaleMaintenanceVehicles(
+      this.maintenanceVehicles,
+    );
+    this.emitChange();
+  }
+
   static handlers = {
     MaintenanceVehicleRealTimeClientStarted: 'storeClient',
     MaintenanceVehicleRealTimeClientStopped: 'clearClient',
+    MaintenanceVehicleRealTimeClientInactive: 'clearStaleVehicles',
     MaintenanceVehicleRealTimeClientMessage: 'handleMessage',
     MaintenanceVehicleRealTimeClientTopicChanged: 'updateSubscriptions',
   };

--- a/app/util/maintenanceUtils.js
+++ b/app/util/maintenanceUtils.js
@@ -3,6 +3,7 @@ import {
   RoadInspectionJobId,
   NonInspectionMaintenanceJobIds,
   BrushingJobIds,
+  MaintenanceVehicleAllowedInactivitySeconds,
 } from '../constants';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -91,4 +92,17 @@ export const getTileLayerFeaturesToRender = ({
     }
     return 0;
   });
+};
+
+export const clearStaleMaintenanceVehicles = vehicles => {
+  const onlyCurrentVehicles = {};
+  Object.values(vehicles).forEach(v => {
+    if (
+      v.timestamp >=
+      Date.now() / 1000 - MaintenanceVehicleAllowedInactivitySeconds
+    ) {
+      onlyCurrentVehicles[v.id] = v;
+    }
+  });
+  return onlyCurrentVehicles;
 };

--- a/test/unit/util/maintenanceUtils.test.js
+++ b/test/unit/util/maintenanceUtils.test.js
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { getTileLayerFeaturesToRender } from '../../../app/util/maintenanceUtils';
 import { BrushingJobIds, RoadInspectionJobId } from '../../../app/constants';
 import { MockTileLayers } from '../test-data/mockTileLayers';
+import {
+  getTileLayerFeaturesToRender,
+  clearStaleMaintenanceVehicles,
+} from '../../../app/util/maintenanceUtils';
 
 describe('maintenanceUtils', () => {
   describe('getTileLayerFeaturesToRender', () => {
@@ -108,6 +111,44 @@ describe('maintenanceUtils', () => {
       it('must not contain duplicate hashes', () => {
         const res = getTileLayerFeaturesToRender(opts);
         expect(hasDuplicateHashes(res)).to.eq(false);
+      });
+    });
+  });
+  describe('clearStaleMaintenanceVehicles', () => {
+    const nyt = Math.floor(Date.now() / 1000);
+    const vehicles = {
+      727: {
+        id: 727,
+        timestamp: nyt,
+      },
+      728: {
+        id: 728,
+        timestamp: nyt - 10,
+      },
+      729: {
+        id: 729,
+        timestamp: nyt - 400,
+      },
+      730: {
+        id: 730,
+        timestamp: nyt - 3,
+      },
+    };
+    it('clears vehicles older than constants.MaintenanceVehicleAllowedInactivitySeconds', () => {
+      const res = clearStaleMaintenanceVehicles(vehicles);
+      expect(res).to.deep.equal({
+        727: {
+          id: 727,
+          timestamp: nyt,
+        },
+        728: {
+          id: 728,
+          timestamp: nyt - 10,
+        },
+        730: {
+          id: 730,
+          timestamp: nyt - 3,
+        },
       });
     });
   });


### PR DESCRIPTION
  - fixes problem where individual maintenance vehicles can
    linger in the UI when they stop sending data
  - remove realtime maintenance vehicles from data structure
    if timestamp is older than 2 minutes
