### PR TITLE
Add weather symbol formatting

### DIFF
--- a/app/component/RoadConditionContent.js
+++ b/app/component/RoadConditionContent.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import moment from 'moment';
 import ComponentUsageExample from './ComponentUsageExample';
 import { lang as exampleLang } from './ExampleData';
+import formatWeatherSymbol from '../util/weatherSymbolUtils';
 
 const RoadConditionContent = ({ forecasts, measuredTime }) => (
   <table className="road-condition-content">
@@ -43,6 +44,9 @@ const RoadConditionContent = ({ forecasts, measuredTime }) => (
           EXTREMELY_POOR_CONDITION: 'extremely-poor',
           CONDITION_COULD_NOT_BE_RESOLVED: 'unresolved',
         }[forecast.overallRoadCondition];
+
+        const weatherSymbol = formatWeatherSymbol(forecast.weatherSymbol);
+
         return (
           <tr key={forecast.forecastName}>
             <td>
@@ -57,9 +61,7 @@ const RoadConditionContent = ({ forecasts, measuredTime }) => (
             </td>
             <td>
               <img
-                src={`https://developer.foreca.com/static/images/symbols/${
-                  forecast.weatherSymbol
-                }.png`}
+                src={`https://developer.foreca.com/static/images/symbols/${weatherSymbol}.png`}
                 style={{ width: '35px' }}
                 alt="weather-symbol"
               />

--- a/app/util/weatherSymbolUtils.js
+++ b/app/util/weatherSymbolUtils.js
@@ -1,0 +1,21 @@
+// RegExps to check if symbol code is in range of d1xx
+const d100RegExp = /^(d|n)([1][0-4][0-2])$/;
+
+/**
+ * Formats weather symbol codes that doesn't have corresponding weather symbol icon available.
+ *
+ * Sometimes digitraffic returns weather codes that doesn't have any corresponding weather icons available. e.g. `d110`, `d120`.
+ *
+ * See https://developer.foreca.com/resources.
+ *
+ * @param {string} weatherSymbol
+ * @returns {string}
+ */
+export default function formatWeatherSymbol(weatherSymbol) {
+  if (d100RegExp.test(weatherSymbol)) {
+    const prefix = weatherSymbol.slice(0, 1);
+    return `${prefix}100`;
+  }
+
+  return weatherSymbol;
+}

--- a/test/unit/util/weatherSymbolUtils.test.js
+++ b/test/unit/util/weatherSymbolUtils.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import formatWeatherSymbol from '../../../app/util/weatherSymbolUtils';
+
+describe('weatherSymbolUtils', () => {
+  describe('formatWeatherSymbol', () => {
+    it('returns formatted weather symbol code', () => {
+      const codes = [
+        '100',
+        '101',
+        '102',
+        '110',
+        '111',
+        '112',
+        '122',
+        '130',
+        '131',
+        '132',
+        '140',
+        '141',
+        '142',
+      ];
+      codes.forEach(code => {
+        expect(formatWeatherSymbol(`d${code}`)).equal('d100');
+        expect(formatWeatherSymbol(`n${code}`)).equal('n100');
+      });
+    });
+
+    it('returns unformatted weather symbol code', () => {
+      expect(formatWeatherSymbol('d100')).equal('d100');
+      expect(formatWeatherSymbol('n100')).equal('n100');
+      expect(formatWeatherSymbol('n240')).equal('n240');
+      expect(formatWeatherSymbol('n210')).equal('n210');
+      expect(formatWeatherSymbol('d431')).equal('d431');
+      expect(formatWeatherSymbol('d600')).equal('d600');
+      expect(formatWeatherSymbol('n600')).equal('n600');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #OULI-26

Changes proposed in this pull request:

Sometimes digitraffic uses weather symbols codes that doesn't have corresponding weather icons.

 *  Add formatting for weather symbol codes d1xx
